### PR TITLE
Add driver.quit() to emulate_admin.py

### DIFF
--- a/.docker/emulate_admin.py
+++ b/.docker/emulate_admin.py
@@ -30,3 +30,4 @@ for (i=0;i<x.length;i++) {
 """)
 time.sleep(10)
 driver.close()
+driver.quit()


### PR DESCRIPTION
Add driver.quit() to emulate_admin.py to fully exit the Selenium process. With only driver.close() the Firefox process is no exiting and a new one is added every minute eventually leading to resource issues in the container.